### PR TITLE
remove stray colon

### DIFF
--- a/jump-char.el
+++ b/jump-char.el
@@ -57,7 +57,7 @@
 ;; This program is free software; you can redistribute it and/or
 ;; modify it under the terms of the GNU General Public License as
 ;; published by the Free Software Foundation; either version 3, or
-:;; (at your option) any later version.
+;; (at your option) any later version.
 ;;
 ;; This program is distributed in the hope that it will be useful,
 ;; but WITHOUT ANY WARRANTY; without even the implied warranty of


### PR DESCRIPTION
Looks like 7ce3f47f08b added a superfluous colon. Luckily `:` is a variable
whose value is `:` so it had no effect.
