### PR TITLE
Add Emacs 25 support.

### DIFF
--- a/jump-char.el
+++ b/jump-char.el
@@ -103,7 +103,6 @@ Set this to nil if you don't need it."
 
 (defvar jump-char-mode nil)
 (defvar jump-char-store (make-hash-table :test 'eq :size 5))
-(defvar jump-char-lazy-highlight-face lazy-highlight-face)
 (defvar jump-char-initial-char nil)
 
 ;;; isearch implementation changed as of Emacs 24.3
@@ -303,14 +302,12 @@ Specifically, make sure point is at beginning of match."
     (unless jump-char-mode
       (puthash 'isearch-mode-map isearch-mode-map jump-char-store)
       (puthash 'isearch-search-fun-function isearch-search-fun-function jump-char-store)
-      (puthash 'lazy-highlight-face lazy-highlight-face jump-char-store)
       (puthash 'isearch-message-prefix (symbol-function 'isearch-message-prefix) jump-char-store)
       (add-hook 'isearch-mode-end-hook 'jump-char-cleanup)
       (add-hook 'isearch-update-post-hook 'jump-char-isearch-update-func)
       (setq jump-char-mode t)
       (setq isearch-mode-map (jump-char-isearch-map))
-      (setq isearch-search-fun-function 'jump-char-search-fun-function)
-      (setq lazy-highlight-face jump-char-lazy-highlight-face))
+      (setq isearch-search-fun-function 'jump-char-search-fun-function))
     (when (and set-mark
              (not (use-region-p)))
       (set-mark-command nil))


### PR DESCRIPTION
In Emacs 25, lazy-highlight-face has been removed. Modern Emacs prefer
using `'foo-face` rather than `(defvar foo-face-name 'foo-face)`, so in
this case we'd normally use `'lazy-highlight`.

However, we don't actually need to set this variable in Emacs 24 or 25
AFAICS.
